### PR TITLE
Migrate to core20 and use new extension

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -5,7 +5,7 @@ description: |
  Xonotic is an addictive, arena-style first person shooter with crisp movement
  and a wide array of weapons. It combines intuitive mechanics with in-your-face
  action to elevate your heart rate. Xonotic is and will always be free-to-play.
-base: core18
+base: core20
 grade: stable
 confinement: strict
 
@@ -15,14 +15,14 @@ architectures:
 
 apps:
   dedicated:
-    extensions: [gnome-3-34]
+    extensions: [gnome-3-38]
     command: Xonotic/xonotic-linux-dedicated.sh
     plugs:
       - network
       - network-bind
 
   xonotic:
-    extensions: [gnome-3-34]
+    extensions: [gnome-3-38]
     command: Xonotic/xonotic-linux-sdl.sh
     environment:
       SDL_AUDIODRIVER: pulse
@@ -59,7 +59,7 @@ parts:
     stage-packages:
       - libasound2
       - libbsd0
-      - libcurl3
+      - libcurl4
       - libgcc1
       - libglu1-mesa
       - libjpeg62


### PR DESCRIPTION
Tested on my workstation using `snapcraft` from edge revision 6002. This can't land until pr-3427 on snapcraft lands - the new extension. 