### PR TITLE
Build package from source to enable additional archs and update

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: xonotic
-version: '0.8.5'
+version: '0.8.6'
 summary: The Free and Fast Arena Shooter
 description: |
  Xonotic is an addictive, arena-style first person shooter with crisp movement

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -11,7 +11,8 @@ confinement: strict
 compression: lzo
 
 architectures:
-  - build-on: amd64
+  - amd64
+  - arm64
 
 layout:
   /usr/share/libdrm:
@@ -20,14 +21,14 @@ layout:
 apps:
   dedicated:
     extensions: [gnome]
-    command: Xonotic/xonotic-linux64-dedicated -basedir /snap/xonotic/current/Xonotic
+    command: Xonotic/xonotic-dedicated -basedir /snap/xonotic/current/Xonotic
     plugs:
       - network
       - network-bind
 
   xonotic:
     extensions: [gnome]
-    command: Xonotic/xonotic-linux64-sdl -basedir /snap/xonotic/current/Xonotic
+    command: Xonotic/xonotic-sdl -basedir /snap/xonotic/current/Xonotic
     environment:
       SDL_AUDIODRIVER: pulse
     plugs:
@@ -43,15 +44,27 @@ apps:
 parts:
   xonotic:
     plugin: dump
-    source: http://dl.xonotic.org/xonotic-$SNAPCRAFT_PROJECT_VERSION.zip
+    source: https://dl.xonotic.org/xonotic-$SNAPCRAFT_PROJECT_VERSION-source.zip
+    override-build: |
+      (cd Xonotic && make both)
+
+      install -Dm755 Xonotic/source/darkplaces/darkplaces-dedicated "$SNAPCRAFT_PART_INSTALL"/Xonotic/xonotic-dedicated
+      install -Dm755 Xonotic/source/darkplaces/darkplaces-sdl "$SNAPCRAFT_PART_INSTALL"/Xonotic/xonotic-sdl
+
+      (cd Xonotic/source/d0_blind_id && make DESTIR="$SNAPCRAFT_PART_INSTALL" install)
     build-packages:
-      - dpkg
+      - automake
+      - libtool
+      - libgmp-dev
+      - libjpeg-turbo8-dev
+      - libsdl2-dev
+      - libxpm-dev
+      - zlib1g-dev
     stage-packages:
       - libasound2
       - libbsd0
       - libgcc1
       - libsdl2-2.0-0
-      - libstdc++6
       - libx11-6
       - libxau6
       - libxcb1
@@ -59,6 +72,9 @@ parts:
       - libxext6
       - libxxf86vm1
       - zlib1g
+  xonotic-data:
+    plugin: dump
+    source: https://dl.xonotic.org/xonotic-$SNAPCRAFT_PROJECT_VERSION.zip
     prime:
       - -Xonotic/Xonotic.app/
       - -Xonotic/*.exe
@@ -68,7 +84,7 @@ parts:
       - -Xonotic/misc
       - -Xonotic/server/rcon2irc
       - -Xonotic/source
-      - -Xonotic/xonotic-linux*-glx*
+      - -Xonotic/xonotic-linux*
       - -Xonotic/xonotic-osx-dedicated
       - -usr/share/bug
       - -usr/share/doc

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -5,7 +5,7 @@ description: |
  Xonotic is an addictive, arena-style first person shooter with crisp movement
  and a wide array of weapons. It combines intuitive mechanics with in-your-face
  action to elevate your heart rate. Xonotic is and will always be free-to-play.
-base: core20
+base: core22
 grade: stable
 confinement: strict
 compression: lzo
@@ -19,14 +19,14 @@ layout:
 
 apps:
   dedicated:
-    extensions: [gnome-3-38]
+    extensions: [gnome]
     command: Xonotic/xonotic-linux64-dedicated -basedir /snap/xonotic/current/Xonotic
     plugs:
       - network
       - network-bind
 
   xonotic:
-    extensions: [gnome-3-38]
+    extensions: [gnome]
     command: Xonotic/xonotic-linux64-sdl -basedir /snap/xonotic/current/Xonotic
     environment:
       SDL_AUDIODRIVER: pulse
@@ -49,21 +49,14 @@ parts:
     stage-packages:
       - libasound2
       - libbsd0
-      - libcurl4
       - libgcc1
-      - libglu1-mesa
-      - libjpeg62
-      - libpulse0
       - libsdl2-2.0-0
       - libstdc++6
-      #- libtxc-dxtn-s2tc0
-      - libvorbisfile3
       - libx11-6
       - libxau6
       - libxcb1
       - libxdmcp6
       - libxext6
-      - libxpm4
       - libxxf86vm1
       - zlib1g
     prime:


### PR DESCRIPTION
I want to play Xonotic on my arm64 laptop. The current build just unpacks the pre-built binaries from upstream. This PR instead builds the binaries from source which allows us to add arm64 support. While I was there I also updated to the newest version, bumped to core22 and moved to gnome-42-2204 which works with my GPU.

This should fix #1 and maybe some of the other bugs too.