### PR TITLE
Maybe fix arm64 build

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -11,8 +11,8 @@ confinement: strict
 compression: lzo
 
 architectures:
-  - amd64
-  - arm64
+  - build-on: amd64
+  - build-on: arm64
 
 layout:
   /usr/share/libdrm:


### PR DESCRIPTION
Try to use the newer `build-on`-style architectures definition to support core22.